### PR TITLE
Install librabbitmq and hiredis into virtualenvs

### DIFF
--- a/manifests/code.pp
+++ b/manifests/code.pp
@@ -27,4 +27,13 @@ define ptero::code (
       subscribe    => Vcsrepo[$title],
     }
   }
+
+  if ! defined("$title-extra-requirements") {
+    exec {"$title-extra-requirements":
+      command => "$title/virtualenv/bin/pip install librabbitmq hiredis",
+      user    => $owner,
+      group   => $group,
+      require => Python::Virtualenv["$title/virtualenv"],
+    }
+  }
 }


### PR DESCRIPTION
The presence of these libraries causes the `celery` and `redis` modules to use the underlying c libraries that they provide, giving some performance improvements.
