### PR TITLE
Fix celery init

### DIFF
--- a/manifests/celery.pp
+++ b/manifests/celery.pp
@@ -47,26 +47,6 @@ define ptero::celery (
     ],
   }
 
-  if ! defined(File['/var/run/celery']) {
-    file {'/var/run/celery':
-      ensure  => 'directory',
-      owner   => 'root',
-      group   => $group,
-      mode    => '2775',
-      require => Group[$group],
-    }
-  }
-
-  if ! defined(File['/var/log/celery']) {
-    file {'/var/log/celery':
-      ensure  => 'directory',
-      owner   => 'root',
-      group   => $group,
-      mode    => '2775',
-      require => Group[$group],
-    }
-  }
-
   service {"celeryd-$title":
     ensure    => running,
     require   => [

--- a/manifests/params/petri.pp
+++ b/manifests/params/petri.pp
@@ -17,7 +17,7 @@ class ptero::params::petri {
   $redis_celery_host = hiera('petri-redis-celery-host', 'localhost')
   $redis_celery_port = hiera('petri-redis-celery-port', 6379)
   $redis_celery_password = hiera('petri-redis-celery-password', '')
-  $redis_celery_url = "redis://:$redis_password@$redis_host:$redis_port"
+  $redis_celery_url = "redis://:$redis_celery_password@$redis_celery_host:$redis_celery_port"
 
   $redis_host = hiera('petri-redis-host', 'localhost')
   $redis_port = hiera('petri-redis-port', 6379)

--- a/templates/init.d.celeryd.erb
+++ b/templates/init.d.celeryd.erb
@@ -78,11 +78,7 @@ _config_sanity() {
 CELERY_APP_ARG="--app=<%= @app %>"
 
 CELERYD_USER='<%= @owner %>'
-
-# Set CELERY_CREATE_DIRS to always create log/pid dirs.
-CELERY_CREATE_DIRS=${CELERY_CREATE_DIRS:-0}
-CELERY_CREATE_RUNDIR=$CELERY_CREATE_DIRS
-CELERY_CREATE_LOGDIR=$CELERY_CREATE_DIRS
+CELERYD_GROUP='<%= @group %>'
 
 CELERYD_LOG_LEVEL=${CELERYD_LOG_LEVEL:-${CELERYD_LOGLEVEL:-$DEFAULT_LOG_LEVEL}}
 CELERY_BIN='<%= @virtualenv %>/bin/celery'
@@ -114,21 +110,15 @@ create_default_dir() {
         echo "- Creating default directory: '$1'"
         mkdir -p "$1"
         maybe_die "Couldn't create directory $1"
-        echo "- Changing permissions of '$1' to 02755"
-        chmod 02755 "$1"
+        echo "- Changing group to ${CELERYD_GROUP} on directory: '$1'"
+        chgrp "${CELERYD_GROUP}" "$1"
+        maybe_die "Couldn't set group $1"
+        echo "- Changing permissions of '$1' to 02775"
+        chmod 02775 "$1"
         maybe_die "Couldn't change permissions for $1"
     fi
 }
 
-
-check_paths() {
-    if [ $CELERY_CREATE_LOGDIR -eq 1 ]; then
-        create_default_dir "$CELERYD_LOG_DIR"
-    fi
-    if [ $CELERY_CREATE_RUNDIR -eq 1 ]; then
-        create_default_dir "$CELERYD_PID_DIR"
-    fi
-}
 
 create_paths() {
     create_default_dir "$CELERYD_LOG_DIR"
@@ -180,24 +170,19 @@ stop_workers() {
 case "$1" in
     start)
         check_dev_null
-        check_paths
+        create_paths
         start_workers
     ;;
 
     stop)
         check_dev_null
-        check_paths
+        create_paths
         stop_workers
     ;;
 
     create-paths)
         check_dev_null
         create_paths
-    ;;
-
-    check-paths)
-        check_dev_null
-        check_paths
     ;;
 
     *)


### PR DESCRIPTION
Workflows were actually not running on the vagrant deployments, because the petri celery workers were not able to connect to the celery backend.
