### PR TITLE
Reduce celery logging level to warn

### DIFF
--- a/templates/init.d.celeryd.erb
+++ b/templates/init.d.celeryd.erb
@@ -27,7 +27,7 @@ CELERY_QUEUE_OPTION=
 
 PID_FILE="/var/run/celery/<%= @title %>.pid"
 LOG_FILE="/var/log/celery/<%= @title %>.log"
-DEFAULT_LOG_LEVEL="INFO"
+DEFAULT_LOG_LEVEL="WARNING"
 DEFAULT_NODES="celery"
 
 


### PR DESCRIPTION
INFO is actually really pretty for celery, as it logs every task at least once.  I currently assume that we don't want that by default.
